### PR TITLE
Update Golang version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && \
 COPY nsjail .
 RUN make -j
 
-FROM golang:1.20.6-bookworm AS run
+FROM golang:1.22.0-bookworm AS run
 WORKDIR /app
 RUN apt-get update && apt-get install -y libseccomp-dev libgmp-dev
 COPY go.mod go.sum ./


### PR DESCRIPTION
Security Update: Golang Docker Image (1.20.6-bookworm)

With golang:1.20.6-bookworm the docker scan showed 6 vulnerabilities  in the stdlib 1.20.6:
- 1 High Severity Vulnerability
- 5 Medium Severity Vulnerabilities

With the update to the golang:1.22.0-bookworm image the vulnerabilities have been fixed.